### PR TITLE
Fix bug in ENV property of environment variable

### DIFF
--- a/src/main/blockchain/blockchain.js
+++ b/src/main/blockchain/blockchain.js
@@ -13,7 +13,7 @@ const minTxFee = 0.0001;
 const dustLimit = 0.0000546;
 
 // Define some env values.
-const environment = Object.assign(
+const environment = 
   {
     DEVELOPMENT: 'development',
     TEST: 'test',
@@ -26,9 +26,7 @@ const environment = Object.assign(
     isTest: () => environment.current === environment.TEST,
     isProduction: () => environment.current === environment.PRODUCTION,
     isMainnet: () => environment.NETWORK === 'mainnet'
-  },
-  process.env
-);
+  };
 
 // If the user has not specified a rpcuser and rpcpassword in their wagerr.conf
 // then generate random RFC4122 version 4 compliant UUIDs for them. Be aware


### PR DESCRIPTION
Remove the Object.assign method and just leave the construction of the 'environment' object as is.

The process.env data is already in ENV property so the Object.assign was only duplicating the data and overriding the properties of the first object passed as a parameter.

In my Fedora 30 exists the property 'process.env.env', so with Object.assign it was overriding `ENV: process.env` (an object) with the value of `process.env.env` (string), and that is why it was failing when trying to access to environment.ENV.HOME.