### PR TITLE
Fixes events list sorting

### DIFF
--- a/src/renderer/store/modules/events.js
+++ b/src/renderer/store/modules/events.js
@@ -31,7 +31,7 @@ function filterEventsByStartingTime(events) {
     return  e.starting - 12 * 60 > moment().unix() &&
             e.starting < moment().add(13, 'days').unix();
 
-  }).sort((x, y) => { x.starting - y.starting });  
+  }).sort((x, y) => x.starting - y.starting);  
 }
 
 function filterEventsByTournament(events, state) {


### PR DESCRIPTION
Now events list is sorted by starting time.

The sorting method was not returning anything so it didn't know how to sort by time