### PR TITLE
Preferences timezone option

### DIFF
--- a/src/renderer/components/splashscreen/SplashScreen.vue
+++ b/src/renderer/components/splashscreen/SplashScreen.vue
@@ -274,6 +274,8 @@ export default {
     // Set the network.
     let blockchainInfo = await blockchainRPC.getBlockchainInfo();
     let network = blockchainInfo.chain === 'test' ? 'Testnet' : 'Mainnet';
+    // load User Config - could use methods access, instead of store.dispatch
+    await this.loadUserSettings(network);
     await this.updateNetworkType(network);
 
     // If Wallet not synced show time behind text.
@@ -285,9 +287,6 @@ export default {
     await this.getWGRTransactionRecords(100);
     await this.getPLBetTransactionList(50);
     await this.getCGBetTransactionList(25);
-
-    // load User Config - could use methods access, instead of store.dispatch
-    await this.loadUserSettings(network);
   }
 };
 </script>

--- a/src/renderer/store/modules/user.js
+++ b/src/renderer/store/modules/user.js
@@ -17,8 +17,10 @@ const OddsFormat = {
 
 const state = function() {
   return {
-    timezone: moment.tz.guess(),
     oddsFormat: OddsFormat.decimal,
+    timezoneOption: 'auto',
+    timezone: moment.tz.guess(),
+    fixedTimezone: moment.tz.guess(),
     showNetworkShare: false,
     accountList: [],
     receivingAddressList: [],
@@ -40,8 +42,14 @@ const displayOdds = function(state, val) {
 };
 
 const getters = {
+  getTimezoneOption: state => {
+    return state.timezoneOption;
+  },
   getTimezone: state => {
     return state.timezone;
+  },
+  getFixedTimezone: state => {
+    return state.fixedTimezone;
   },
   getOddsFormat: state => {
     return state.oddsFormat;
@@ -78,6 +86,20 @@ const actions = {
     preferencesStore.set('oddsFormat', state.oddsFormat);
   },
 
+  updateTimezoneOption({ commit, state }, timezoneOption) {
+    commit('setTimezoneOption', timezoneOption);
+    preferencesStore.set('timezoneOption', state.timezoneOption);
+  },
+
+  updateTimezone({ commit, state }, timezone) {
+    commit('setTimezone', timezone);
+    preferencesStore.set('timezone', state.timezone);
+  },
+  updateFixedTimezone({ commit, state }, fixedTimezone) {
+    commit('setFixedTimezone', fixedTimezone);
+    preferencesStore.set('fixedTimezone', state.fixedTimezone);
+  },
+
   // Loaded on Splash screen
   loadUserSettings({ dispatch, getters }, networkType) {
     const network = networkType === 'Testnet' ? '_testnet' : '';
@@ -86,6 +108,15 @@ const actions = {
     });
     if (preferencesStore.has('oddsFormat')) {
       dispatch('updateOddsFormat', Number(preferencesStore.get('oddsFormat')));
+    }
+    if (preferencesStore.has('timezoneOption')) {
+      dispatch('updateTimezoneOption', preferencesStore.get('timezoneOption'));
+    }
+    if (preferencesStore.has('timezone')) {
+      dispatch('updateTimezone', preferencesStore.get('timezone'));
+    }
+    if (preferencesStore.has('fixedTimezone')) {
+      dispatch('updateFixedTimezone', preferencesStore.get('fixedTimezone'));
     }
     if (preferencesStore.has('showNetworkShare')) {
       dispatch(
@@ -214,7 +245,15 @@ const mutations = {
   setOddsFormat(state, format) {
     state.oddsFormat = format;
   },
-
+  setTimezoneOption(state, timezoneOption) {
+    state.timezoneOption = timezoneOption;
+  },
+  setTimezone(state, timezone) {
+    state.timezone = timezone;
+  },
+  setFixedTimezone(state, fixedTimezone) {
+    state.fixedTimezone = fixedTimezone;
+  },
   setShowNetworkShare(state, value) {
     state.showNetworkShare = value;
     preferencesStore.set('showNetworkShare', state.showNetworkShare);

--- a/src/renderer/store/modules/user.js
+++ b/src/renderer/store/modules/user.js
@@ -20,7 +20,6 @@ const state = function() {
     oddsFormat: OddsFormat.decimal,
     timezoneOption: 'auto',
     timezone: moment.tz.guess(),
-    fixedTimezone: moment.tz.guess(),
     showNetworkShare: false,
     accountList: [],
     receivingAddressList: [],
@@ -47,9 +46,6 @@ const getters = {
   },
   getTimezone: state => {
     return state.timezone;
-  },
-  getFixedTimezone: state => {
-    return state.fixedTimezone;
   },
   getOddsFormat: state => {
     return state.oddsFormat;
@@ -95,10 +91,6 @@ const actions = {
     commit('setTimezone', timezone);
     preferencesStore.set('timezone', state.timezone);
   },
-  updateFixedTimezone({ commit, state }, fixedTimezone) {
-    commit('setFixedTimezone', fixedTimezone);
-    preferencesStore.set('fixedTimezone', state.fixedTimezone);
-  },
 
   // Loaded on Splash screen
   loadUserSettings({ dispatch, getters }, networkType) {
@@ -112,8 +104,6 @@ const actions = {
     if (preferencesStore.has('timezone')) {
       dispatch('updateTimezone', preferencesStore.get('timezone'));
     }
-    if (preferencesStore.has('fixedTimezone')) {
-      dispatch('updateFixedTimezone', preferencesStore.get('fixedTimezone'));
     if (preferencesStore.has('timezoneOption')) {
       // On launch and after setting the timezone value from the preferences
       // file, check if the timezone option preference is set to 'auto'. If it
@@ -258,9 +248,6 @@ const mutations = {
   },
   setTimezone(state, timezone) {
     state.timezone = timezone;
-  },
-  setFixedTimezone(state, fixedTimezone) {
-    state.fixedTimezone = fixedTimezone;
   },
   setShowNetworkShare(state, value) {
     state.showNetworkShare = value;

--- a/src/renderer/store/modules/user.js
+++ b/src/renderer/store/modules/user.js
@@ -109,14 +109,22 @@ const actions = {
     if (preferencesStore.has('oddsFormat')) {
       dispatch('updateOddsFormat', Number(preferencesStore.get('oddsFormat')));
     }
-    if (preferencesStore.has('timezoneOption')) {
-      dispatch('updateTimezoneOption', preferencesStore.get('timezoneOption'));
-    }
     if (preferencesStore.has('timezone')) {
       dispatch('updateTimezone', preferencesStore.get('timezone'));
     }
     if (preferencesStore.has('fixedTimezone')) {
       dispatch('updateFixedTimezone', preferencesStore.get('fixedTimezone'));
+    if (preferencesStore.has('timezoneOption')) {
+      // On launch and after setting the timezone value from the preferences
+      // file, check if the timezone option preference is set to 'auto'. If it
+      // is update the timezone value with a new guess at which timezone the
+      // user is in. This solves the problem of a laptop user moving across
+      // timezones or DST starting/ending.
+      let tzOption = preferencesStore.get('timezoneOption');
+      dispatch('updateTimezoneOption', tzOption);
+      if (tzOption === 'auto') {
+        dispatch('updateTimezone', moment.tz.guess());
+      }
     }
     if (preferencesStore.has('showNetworkShare')) {
       dispatch(

--- a/src/renderer/views/Preferences.vue
+++ b/src/renderer/views/Preferences.vue
@@ -11,8 +11,7 @@
                 <tr class="info-row">
                   <td>Odds Display</td>
                   <td class="aligncenter">
-                    <div id="oddsChoice">
-                      <form id="oddschoiceform" action="#" @submit.prevent>
+                    <div class="inline">
                         <p>
                           <label>
                             <input
@@ -58,7 +57,47 @@
                             <span>American</span>
                           </label>
                         </p>
-                      </form>
+                      <br />
+                    </div>
+                  </td>
+                </tr>
+                <tr class="info-row">
+                  <td>Timezone</td>
+                  <td class="aligncenter">
+                    <div class="inline">
+                        <p>
+                          <label>
+                            <input
+                              name="timezoneOption"
+                              type="radio"
+                              value="auto"
+                              @change="changeTimezoneOption"
+                              :checked="getTimezoneOption === 'auto'"
+                            />
+                            <span>Auto-detect</span>
+                          </label>
+                        </p>
+                        <p>
+                          <label>
+                            <input
+                              name="timezoneOption"
+                              type="radio"
+                              value="fixed"
+                              @change="changeTimezoneOption"
+                              :checked="getTimezoneOption === 'fixed'"
+                            />
+                            <span>Fixed</span>
+                          </label>
+                        </p>
+                        <select
+                          class="browser-default timezone"
+                          :disabled="getTimezoneOption === 'auto'"
+                          @change="changeTimezone"
+                        >
+                            <option v-for="tz in timezones" :selected="tz === getTimezone" :key="tz">
+                              {{ tz }}
+                            </option>
+                        </select>
                       <br />
                     </div>
                   </td>
@@ -111,6 +150,7 @@ import Store from 'electron-store';
 import { mapGetters, mapActions } from 'vuex';
 import wagerrRPC from '@/services/api/wagerrRPC';
 import { getWagerrConfPath } from '../../main/blockchain/blockchain';
+import moment from 'moment';
 
 export default {
   name: 'Preferences',
@@ -119,6 +159,23 @@ export default {
     ...mapActions(['updateOddsFormat', 'toggleShowNetworkShare']),
     changeOddsFormat: function(event) {
       this.$store.dispatch('updateOddsFormat', Number(event.target.value));
+    },
+    changeTimezoneOption: function(event) {
+      const timezoneOption = event.target.value;
+      this.$store.dispatch('updateTimezoneOption', timezoneOption);
+
+      if (timezoneOption === 'auto') {
+        this.$store.dispatch('updateTimezone', moment.tz.guess());
+      } else if (timezoneOption === 'fixed') {
+        this.$store.dispatch('updateTimezone', this.getFixedTimezone);
+      }
+    },
+    changeTimezone: function(event) {
+      const newTimezone = event.target.value;
+      this.$store.dispatch('updateTimezone', newTimezone);
+      if (this.getTimezoneOption === 'fixed') {
+        this.$store.dispatch('updateFixedTimezone', newTimezone);
+      }
     },
 
     oddsFormatChecked: function(format) {
@@ -160,7 +217,10 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['getOddsFormats', 'getOddsFormat', 'getShowNetworkShare'])
+    ...mapGetters(['getOddsFormats', 'getOddsFormat', 'getTimezoneOption', 'getTimezone', 'getFixedTimezone', 'getShowNetworkShare']),
+    'timezones': function() {
+      return moment.tz.names();
+    }
   },
 
   data: function() {
@@ -228,9 +288,13 @@ export default {
     border-right: 2px solid $wagerr-red;
     border-bottom: 2px solid $wagerr-red;
   }
-  #oddschoiceform p {
+  div.inline p {
     display: inline-block;
     padding: 0 10px;
+  }
+  select.timezone {
+    max-width: 300px;
+    margin: auto;
   }
 }
 </style>

--- a/src/renderer/views/Preferences.vue
+++ b/src/renderer/views/Preferences.vue
@@ -155,11 +155,33 @@ import moment from 'moment';
 export default {
   name: 'Preferences',
 
+  data: function() {
+    return {
+      confPath: getWagerrConfPath()
+    };
+  },
+
+  computed: {
+    ...mapGetters([
+      'getOddsFormats',
+      'getOddsFormat',
+      'getTimezoneOption',
+      'getTimezone',
+      'getShowNetworkShare'
+    ]),
+
+    'timezones': function() {
+      return moment.tz.names();
+    }
+  },
+
   methods: {
     ...mapActions(['updateOddsFormat', 'toggleShowNetworkShare']),
+
     changeOddsFormat: function(event) {
       this.$store.dispatch('updateOddsFormat', Number(event.target.value));
     },
+
     changeTimezoneOption: function(event) {
       const timezoneOption = event.target.value;
       this.$store.dispatch('updateTimezoneOption', timezoneOption);
@@ -167,15 +189,13 @@ export default {
       if (timezoneOption === 'auto') {
         this.$store.dispatch('updateTimezone', moment.tz.guess());
       } else if (timezoneOption === 'fixed') {
-        this.$store.dispatch('updateTimezone', this.getFixedTimezone);
+        this.$store.dispatch('updateTimezone', this.getTimezone);
       }
     },
+
     changeTimezone: function(event) {
       const newTimezone = event.target.value;
       this.$store.dispatch('updateTimezone', newTimezone);
-      if (this.getTimezoneOption === 'fixed') {
-        this.$store.dispatch('updateFixedTimezone', newTimezone);
-      }
     },
 
     oddsFormatChecked: function(format) {
@@ -214,19 +234,6 @@ export default {
           });
       }
     }
-  },
-
-  computed: {
-    ...mapGetters(['getOddsFormats', 'getOddsFormat', 'getTimezoneOption', 'getTimezone', 'getFixedTimezone', 'getShowNetworkShare']),
-    'timezones': function() {
-      return moment.tz.names();
-    }
-  },
-
-  data: function() {
-    return {
-      confPath: getWagerrConfPath()
-    };
   }
 };
 </script>


### PR DESCRIPTION
Add a new option in preferences menu to let user change app timezone. User can decide between an auto-detected or a fixed timezone