### PR TITLE
Tells Vue Router to scroll top when component is changed. This way, t…

### DIFF
--- a/src/renderer/router.js
+++ b/src/renderer/router.js
@@ -23,6 +23,9 @@ Vue.use(Router);
 
 export default new Router({
   mode: 'history',
+  scrollBehavior () {
+    return { x: 0, y: 0 }
+  },
   routes: [
     { path: '/', component: Wallet },
     { path: '/bet_history', component: BetHistory },


### PR DESCRIPTION
…he empty space at the bottom doesn't appear that often.

To reproduce the bug, go to a tab with a long scroll and scroll down, then change to a tab with a much shorter scroll. An empty space will appear at the bottom of the page + the position of the scroll is not convenient.

This patch reduces the amount of times this empty space appears, it also moves the scroll to the top when changing tabs making it more convenient. 

Despite the big improvement, the empty space at the bottom appears sometimes at random.